### PR TITLE
List of variants to omit from dating

### DIFF
--- a/config/validation_msprime.yaml
+++ b/config/validation_msprime.yaml
@@ -2,7 +2,7 @@
 output-dir: "validation-msprime-output"  # where to place validation results and simulations
 random-seed: 1024  # global random seed
 num-replicates: 5  # number of replicate ARGs to simulate
-mask-sequence: [0.0, 0]  # randomly mask intervals with this [density, mean length]
+mask-sequence: [0.0, 0]  # randomly mask intervals with this [rate, mean length]
 mask-variants: 0.2  # randomly mask this proportion of variants
 inaccessible-bed: "example/example.mask.bed"  # path to bedfile with masked intervals (will be combined with simulated intervals, can be omitted)
 prop-mispolarise: 0.0  # randomly mispolarise this proportion of biallelic variants (or "maf" for major-allele polarisation)

--- a/config/validation_stdpopsim.yaml
+++ b/config/validation_stdpopsim.yaml
@@ -2,7 +2,7 @@
 output-dir: "validation-stdpopsim-output"  # where to place validation results and simulations
 random-seed: 1024  # global random seed
 num-replicates: 5  # number of replicate ARGs to simulate
-mask-sequence: [0.0001, 800]  # randomly mask intervals with this [density, mean length]
+mask-sequence: [1.0e-9, 800]  # randomly mask intervals with this [rate, mean length]
 mask-variants: 0.2  # randomly mask this proportion of variants
 inaccessible-bed: ~  # path to bedfile with masked intervals (will be combined with simulated intervals, can be omitted)
 prop-mispolarise: 0.0  # randomly mispolarise this proportion of biallelic variants (or "maf" for major-allele polarisation)

--- a/experiments/ablation/no_mutational_span.yaml
+++ b/experiments/ablation/no_mutational_span.yaml
@@ -2,7 +2,7 @@
 output-dir: "ablation-no-mutational-span"  # where to place validation results and simulations
 random-seed: 1024  # global random seed
 num-replicates: 5  # number of replicate ARGs to simulate
-mask-sequence: [0.0001, 800]  # randomly mask intervals with this [density, mean length]
+mask-sequence: [1.0e-9, 800]  # randomly mask intervals with this [density, mean length]
 mask-variants: 0.2  # randomly mask this proportion of variants
 inaccessible-bed: "experiments/ablation/chr1.gaps.bed"  # path to bedfile with masked intervals (will be combined with simulated intervals, can be omitted)
 prop-mispolarise: 0.0  # randomly mispolarise this proportion of biallelic variants (or "ref", "maf", "frq")

--- a/experiments/ablation/omitted_variants.yaml
+++ b/experiments/ablation/omitted_variants.yaml
@@ -1,5 +1,5 @@
 # --- settings for validation workflow using a stdpopsim species and model --- #
-output-dir: "ablation-missing-data"  # where to place validation results and simulations
+output-dir: "ablation-omitted"  # where to place validation results and simulations
 random-seed: 1024  # global random seed
 num-replicates: 5  # number of replicate ARGs to simulate
 mask-sequence: [1.0e-9, 800]  # randomly mask intervals with this [density, mean length]
@@ -20,3 +20,6 @@ stdpopsim-config:  # simulation settings
         left: 180.0e+6
         right: 230.0e+6
         genetic_map: "HapMapII_GRCh38"
+
+# hidden arguments
+record-structural-variants: True

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -126,6 +126,7 @@ checkpoint chunk_chromosomes:
         recomb_rate = os.path.join(CHROM_PATH, "{chrom}.recomb_rate.p"),
         inaccessible = os.path.join(CHROM_PATH, "{chrom}.inaccessible.p"),
         filtered = os.path.join(CHROM_PATH, "{chrom}.filtered.p"),
+        omitted = os.path.join(CHROM_PATH, "{chrom}.omitted.p"),
         metadata = os.path.join(CHROM_PATH, "{chrom}.vcf.samples.p"),
         chunks = os.path.join(CHROM_PATH, "{chrom}.chunks.p"),
         windows = os.path.join(CHROM_PATH, "{chrom}.windows.p"),
@@ -201,6 +202,7 @@ rule run_polegon:
         branches = os.path.join(CHUNK_PATH, "{id}_branches_{rep}.txt"),
         nodes = os.path.join(CHUNK_PATH, "{id}_nodes_{rep}.txt"),
         muts = os.path.join(CHUNK_PATH, "{id}_muts_{rep}.txt"),
+        omitted = rules.chunk_chromosomes.output.omitted,
     output:  
         # TODO mark temp
         nodes = os.path.join(CHUNK_PATH, "{id}_polegon_{rep}.txt"),
@@ -209,6 +211,7 @@ rule run_polegon:
         # for debugging:
         use_polegon = config.get("use-polegon", True),
         use_mutational_span = config.get("use-mutational-span", True),
+        drop_omitted = config.get("drop-omitted", True),
     log:
         log = os.path.join(CHUNK_PATH, "{id}.{rep}.log"),
     script:
@@ -241,6 +244,7 @@ rule merge_chunks:
     input:
         chunks = rules.chunk_chromosomes.output.chunks,
         inaccessible = rules.chunk_chromosomes.output.inaccessible,
+        omitted = rules.chunk_chromosomes.output.omitted,
         metadata = rules.chunk_chromosomes.output.metadata,
         alleles = rules.chunk_chromosomes.output.alleles,
         params = merge_chunks_params,

--- a/workflow/scripts/tree_statistics.py
+++ b/workflow/scripts/tree_statistics.py
@@ -39,8 +39,12 @@ accessible = msprime.RateMap(
 )
 accessible_bp = np.diff(accessible.get_cumulative_mass(windows.position))
 
+# remove sites that were omitted from dating
+omitted = np.array([s.metadata["omitted"] for s in trees.sites()])
+trees = trees.delete_sites(np.flatnonzero(omitted))
+
 # statistics that depend on observed sites
-repolarised = np.mean([s.ancestral_state != alleles[s.position][0] for s in trees.sites()])
+repolarised = np.mean([s.metadata["flipped"] for s in trees.sites()])
 multimapped = np.mean(np.bincount(trees.mutations_site, minlength=trees.num_sites))
 # TODO: split by input frequency?
 

--- a/workflow/scripts/validation/simulate_msprime.py
+++ b/workflow/scripts/validation/simulate_msprime.py
@@ -29,7 +29,8 @@ config = snakemake.params.config
 model = msprime.Demography.from_demes(demes.load(config["demographic-model"]))
 recombination_map = msprime.RateMap.read_hapmap(config["recombination-map"])
 
-interval_mask_density, interval_mask_length = snakemake.params.mask_sequence
+interval_mask_rate, interval_mask_length = snakemake.params.mask_sequence
+record_structural_variants = snakemake.params.record_structural_variants
 variant_mask_prop = snakemake.params.mask_variants
 mispolarised_prop = snakemake.params.prop_mispolar
 inaccessible_bed = snakemake.params.inaccessible_bed
@@ -51,12 +52,27 @@ ts = msprime.sim_mutations(
     random_seed=subseed[4],
 )
 
-sequence_mask = simulate_sequence_mask(ts, interval_mask_density, interval_mask_length, subseed[1])
+# add small structural variants and corresponding mask
+ts, sv_mask, sequence_mask = simulate_sequence_mask(
+    ts, 
+    rate=interval_mask_rate, 
+    length=interval_mask_length, 
+    record_variants=record_structural_variants,
+    seed=subseed[1], 
+)
 bed_to_bitmask(inaccessible_bed, sequence_mask) # applied on top of simulated mask
+
+# filter a random proportion of variants
 variant_mask = simulate_variant_mask(ts, variant_mask_prop, subseed[2])
 
-# filter out masked sites from true trees, for the sake of downstream comparison
+# adjust masks to remove overlap
 site_position = ts.sites_position.astype(int)
+assert sv_mask.size == variant_mask.size == site_position.size
+sv_mask[sequence_mask[site_position]] = False
+variant_mask[sequence_mask[site_position]] = False
+variant_mask[sv_mask] = False
+
+# filter out masked sites from true trees, for the sake of downstream comparison
 site_masked = np.logical_or(sequence_mask[site_position], variant_mask)
 ts = ts.delete_sites(np.flatnonzero(site_masked))
 
@@ -65,6 +81,11 @@ bedmask = open(f"{prefix}.mask.bed", "w")
 bedmask.write(bitmask_to_bed(sequence_mask, contig_name))
 bedmask.close()
 assert_valid_bedmask(sequence_mask, f"{prefix}.mask.bed")
+
+# write out variants to omit from dating as one-based positions
+omitted = open(f"{prefix}.omit.txt", "w")
+omitted.write("\n".join([str(x + 1) for x in site_position[sv_mask]]) + "\n")
+omitted.close()
 
 # write out variant mask as one-based positions
 sitemask = open(f"{prefix}.filter.txt", "w")

--- a/workflow/scripts/validation/simulate_stdpopsim.py
+++ b/workflow/scripts/validation/simulate_stdpopsim.py
@@ -31,7 +31,8 @@ contig = species.get_contig(**config["contig"])
 engine = stdpopsim.get_engine("msprime")  #FIXME: use SLiM if DFE
 contig_name, *_ = contig.coordinates
 
-interval_mask_density, interval_mask_length = snakemake.params.mask_sequence
+interval_mask_rate, interval_mask_length = snakemake.params.mask_sequence
+record_structural_variants = snakemake.params.record_structural_variants
 variant_mask_prop = snakemake.params.mask_variants
 mispolarised_prop = snakemake.params.prop_mispolar
 inaccessible_bed = snakemake.params.inaccessible_bed
@@ -47,12 +48,27 @@ ts = engine.simulate(
     seed=subseed[0],
 )
 
-sequence_mask = simulate_sequence_mask(ts, interval_mask_density, interval_mask_length, subseed[1])
+# add small structural variants and corresponding mask
+ts, sv_mask, sequence_mask = simulate_sequence_mask(
+    ts, 
+    rate=interval_mask_rate, 
+    length=interval_mask_length, 
+    record_variants=record_structural_variants,
+    seed=subseed[1], 
+)
 bed_to_bitmask(inaccessible_bed, sequence_mask) # applied on top of simulated mask
+
+# filter a random proportion of variants
 variant_mask = simulate_variant_mask(ts, variant_mask_prop, subseed[2])
 
-# filter out masked sites from true trees, for the sake of downstream comparison
+# adjust masks to remove overlap
 site_position = ts.sites_position.astype(int)
+assert sv_mask.size == variant_mask.size == site_position.size
+sv_mask[sequence_mask[site_position]] = False
+variant_mask[sequence_mask[site_position]] = False
+variant_mask[sv_mask] = False
+
+# filter out masked sites from true trees, for the sake of downstream comparison
 site_masked = np.logical_or(sequence_mask[site_position], variant_mask)
 ts = ts.delete_sites(np.flatnonzero(site_masked))
 
@@ -61,6 +77,11 @@ bedmask = open(f"{prefix}.mask.bed", "w")
 bedmask.write(bitmask_to_bed(sequence_mask, contig_name))
 bedmask.close()
 assert_valid_bedmask(sequence_mask, f"{prefix}.mask.bed")
+
+# write out variants to omit from dating as one-based positions
+omitted = open(f"{prefix}.omit.txt", "w")
+omitted.write("\n".join([str(x + 1) for x in site_position[sv_mask]]) + "\n")
+omitted.close()
 
 # write out variant mask as one-based positions
 sitemask = open(f"{prefix}.filter.txt", "w")

--- a/workflow/validation.smk
+++ b/workflow/validation.smk
@@ -122,6 +122,8 @@ rule simulate_arg:
         prop_mispolar = PROP_MISPOLAR,
         inaccessible_bed = INACCESSIBLE_BED,
         config = SIMULATION_CONFIG,
+        # FIXME: hidden for now
+        record_structural_variants = config.get("record-structural-variants", False),
     script: SIMULATION_SCRIPT
 
 


### PR DESCRIPTION
Often there will be variants that aren't following the desired clock (SVs, protein coding substitutions, etc), but that are phylogentically informative and interesting in their own right. In this case we may want to build them into the trees, but not use them whilst dating. These can be flagged by an input `<chromosome_name>.omit.txt` and should be noted in the per-chunk polegon logs.