### PR TITLE
Fix to Child-Parent error

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -118,7 +118,7 @@ checkpoint chunk_chromosomes:
     input: 
         vcf = os.path.join(INPUT_DIR, "{chrom}.vcf.gz"),
     output:
-        chunks_dir = directory(CHUNK_PATH),
+        chunks_check = touch(os.path.join(CHROM_PATH, "chunks.done")),
         # TODO: mark VCF temp, but need to include as input to SINGER to make persistant
         vcf = os.path.join(CHROM_PATH, "{chrom}.vcf"),
         vcf_stats = os.path.join(CHROM_PATH, "{chrom}.vcf.stats.p"),
@@ -159,6 +159,7 @@ checkpoint chunk_chromosomes:
         model_masked_sequence = config.get("model-masked-sequence", True),
         random_polarisation = config.get("random-polarisation", True),
         remove_unpolarised = config.get("remove-unpolarised", False),
+        chunks_dir = CHUNK_PATH
     script:
         "scripts/chunk_chromosomes.py"
 
@@ -168,7 +169,8 @@ rule run_singer:
     Run SINGER chunk-by-chunk.
     """
     input:
-        vcf = rules.chunk_chromosomes.output.vcf,  # not used, mark dependency
+        vcf = rules.chunk_chromosomes.output.vcf,  # not used, mark dependency,
+        chunks_check = rules.chunk_chromosomes.output.chunks_check, # not used, mark dependency,
         params = os.path.join(CHUNK_PATH, "{id}.yaml"),
     output:  
         # TODO: mark temp
@@ -224,7 +226,8 @@ rule run_polegon:
 
 
 def merge_chunks_params(wildcards):
-    dir = checkpoints.chunk_chromosomes.get(chrom=wildcards.chrom).output.chunks_dir
+    chk = checkpoints.chunk_chromosomes.get(chrom=wildcards.chrom).output.chunks_check
+    dir = os.path.join(OUTPUT_DIR, wildcards.chrom, "chunks")
     out = expand(
         os.path.join(dir, "{id}.yaml"),
         id=glob_wildcards(os.path.join(dir, "{id}.yaml")).id
@@ -233,7 +236,8 @@ def merge_chunks_params(wildcards):
 
 
 def merge_chunks_input(wildcards, regex):
-    dir = checkpoints.chunk_chromosomes.get(chrom=wildcards.chrom).output.chunks_dir
+    chk = checkpoints.chunk_chromosomes.get(chrom=wildcards.chrom).output.chunks_check
+    dir = os.path.join(OUTPUT_DIR, wildcards.chrom, "chunks")
     out = expand(
         os.path.join(dir, f"{{id}}_{regex}_{{rep}}.txt"),
         rep=wildcards.rep,

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -226,8 +226,8 @@ rule run_polegon:
 
 
 def merge_chunks_params(wildcards):
-    chk = checkpoints.chunk_chromosomes.get(chrom=wildcards.chrom).output.chunks_check
-    dir = os.path.join(OUTPUT_DIR, wildcards.chrom, "chunks")
+    _ = checkpoints.chunk_chromosomes.get(chrom=wildcards.chrom).output.chunks_check # need this to trigger checkpoint
+    dir = expand(CHUNK_PATH, chrom=wildcards.chrom)[0]
     out = expand(
         os.path.join(dir, "{id}.yaml"),
         id=glob_wildcards(os.path.join(dir, "{id}.yaml")).id
@@ -236,8 +236,8 @@ def merge_chunks_params(wildcards):
 
 
 def merge_chunks_input(wildcards, regex):
-    chk = checkpoints.chunk_chromosomes.get(chrom=wildcards.chrom).output.chunks_check
-    dir = os.path.join(OUTPUT_DIR, wildcards.chrom, "chunks")
+    _ = checkpoints.chunk_chromosomes.get(chrom=wildcards.chrom).output.chunks_check # need this to trigger checkpoint
+    dir = expand(CHUNK_PATH, chrom=wildcards.chrom)[0]
     out = expand(
         os.path.join(dir, f"{{id}}_{regex}_{{rep}}.txt"),
         rep=wildcards.rep,

--- a/workflow/scripts/chunk_chromosomes.py
+++ b/workflow/scripts/chunk_chromosomes.py
@@ -547,8 +547,8 @@ pickle.dump(omitted_positions, open(snakemake.output.omitted, "wb"))
 # meantime, we explicitly use mean rates.
 
 # dump SINGER parameters for each chunk
-chunks_dir = snakemake.output.chunks_dir
-os.makedirs(f"{chunks_dir}")
+chunks_dir = snakemake.params.chunks_dir
+os.makedirs(f"{chunks_dir}", exist_ok=True)
 seeds = rng.integers(0, 2 ** 10, size=(filter_chunks.size, 2))
 vcf_prefix = snakemake.output.vcf.removesuffix(".vcf")
 for i in np.flatnonzero(filter_chunks):


### PR DESCRIPTION
I ran into an issue with running the pipeline due to ChildIOException using `snakemake==9.17.1`:

```
ChildIOException:
File/directory is a child to another output:
(PosixPath('/home/exacloud/gscratch/WallLab/rodrigmu/singer-snakemake/results/Nanc-10000_NpopA-10000_NpopB-10000_split_time-500_rep-9_seed-391115/1/chunks'), chunk_chromosomes)
(PosixPath('/home/exacloud/gscratch/WallLab/rodrigmu/singer-snakemake/results/Nanc-10000_NpopA-10000_NpopB-10000_split_time-500_rep-9_seed-391115/1/chunks/000225_branches_0.txt'), run_singer)
```

I fixed this by removing the creation of `chunks` directory as output and instead creating a check file. This ran for my own config and for the example provided in the package.
