### PR TITLE
Change snakemake version to 9.16.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 tskit @ git+https://github.com/tskit-dev/tskit.git#subdirectory=python
 tszip
-snakemake>=8.0.0
+snakemake=9.16.2
 stdpopsim>=0.3.0
 demes
 msprime


### PR DESCRIPTION
Roll back due to bug in 9.16.3 in interpreting runtime values as seconds not minutes: https://github.com/snakemake/snakemake/issues/4039